### PR TITLE
Changing ID to be an i64 and making some methods public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ggst-api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ pub enum Character {
     Goldlewis,
     Jacko,
     HappyChaos,
+    Baiken,
 }
 
 impl fmt::Display for Character {
@@ -160,6 +161,7 @@ impl fmt::Display for Character {
             Character::Goldlewis => write!(f, "Goldlewis Dickinson"),
             Character::Jacko => write!(f, "Jack-o"),
             Character::HappyChaos => write!(f, "Happy Chaos"),
+            Character::Baiken => write!(f, "Baiken"),
         }
     }
 }
@@ -190,6 +192,7 @@ impl Character {
             0x0f => Ok(Character::Goldlewis),
             0x10 => Ok(Character::Jacko),
             0x11 => Ok(Character::HappyChaos),
+            0x12 => Ok(Character::Baiken),
             _ => Err(Error::InvalidArgument(format!(
                 "{:x} is not a valid character code",
                 c
@@ -222,6 +225,7 @@ impl Character {
             Character::Goldlewis => 0x0f,
             Character::Jacko => 0x10,
             Character::HappyChaos => 0x11,
+            Character::Baiken => 0x12,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl Floor {
     /// Create a floor from a byte representation
     ///
     /// See https://github.com/optix2000/totsugeki/issues/35#issuecomment-922516535 for mapping
-    fn from_u8(c: u8) -> Result<Self> {
+    pub fn from_u8(c: u8) -> Result<Self> {
         match c {
             0x01 => Ok(Floor::F1),
             0x02 => Ok(Floor::F2),
@@ -285,7 +285,7 @@ impl Floor {
     }
 
     /// Similar to to_u8() but it directly returns its string representation for url building
-    fn to_hex(&self) -> String {
+    pub fn to_hex(&self) -> String {
         match self {
             Floor::F1 => "01".into(),
             Floor::F2 => "02".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,20 +41,6 @@ impl fmt::Display for Player {
     }
 }
 
-impl Player {
-    pub fn id(&self) -> i64 {
-        self.id
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn character(&self) -> Character {
-        self.character
-    }
-}
-
 /// Indicates which player won a match
 #[derive(Hash, PartialEq, Eq, Debug, Clone, Copy, PartialOrd, Ord)]
 #[cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,6 +284,22 @@ impl Floor {
         }
     }
 
+    pub fn to_u8(self) -> u8 {
+        match self {
+            Floor::F1 => 1,
+            Floor::F2 => 2,
+            Floor::F3 => 3,
+            Floor::F4 => 4,
+            Floor::F5 => 5,
+            Floor::F6 => 6,
+            Floor::F7 => 7,
+            Floor::F8 => 8,
+            Floor::F9 => 9,
+            Floor::F10 => 10,
+            Floor::Celestial => 99,
+        }
+    }
+
     /// Similar to to_u8() but it directly returns its string representation for url building
     pub fn to_hex(&self) -> String {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ pub use requests::*;
 )]
 #[derivative(Hash)]
 pub struct Player {
-    id: u64,
-    character: Character,
+    pub id: i64,
+    pub character: Character,
     #[derivative(Hash = "ignore")]
-    name: String,
+    pub name: String,
 }
 
 impl PartialEq for Player {
@@ -41,7 +41,7 @@ impl fmt::Display for Player {
 }
 
 impl Player {
-    pub fn id(&self) -> u64 {
+    pub fn id(&self) -> i64 {
         self.id
     }
 
@@ -61,7 +61,7 @@ impl Player {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-enum Winner {
+pub enum Winner {
     Player1,
     Player2,
 }
@@ -75,10 +75,10 @@ enum Winner {
     serde(crate = "serde_crate")
 )]
 pub struct Match {
-    timestamp: DateTime<Utc>,
-    floor: Floor,
-    players: (Player, Player),
-    winner: Winner,
+    pub timestamp: DateTime<Utc>,
+    pub floor: Floor,
+    pub players: (Player, Player),
+    pub winner: Winner,
 }
 
 impl Match {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -36,10 +36,10 @@ impl Context {
     }
 }
 
-fn id_from_bytes(bytes: &[u8]) -> Result<u64> {
+fn id_from_bytes(bytes: &[u8]) -> Result<i64> {
     let s =
         str::from_utf8(bytes).map_err(|_| Error::ParsingBytesError("could not parse userid"))?;
-    Ok(u64::from_str_radix(s, 10)
+    Ok(i64::from_str_radix(s, 10)
         .map_err(|_| Error::ParsingBytesError("could not parse userid from String"))?)
 }
 


### PR DESCRIPTION
I think having it be an i64 makes sense given how seldom u64s are used in C++ and DBs, and it matches what the database I'm using expects.