### PR TITLE
Split the version part of the query string out, updated API version to 0.1.0

### DIFF
--- a/src/requests.rs
+++ b/src/requests.rs
@@ -86,7 +86,7 @@ pub async fn get_replays<A, B, C, D, E>(
         let replays_per_page_hex = format!("{:02X}", replays_per_page);
         let query_string = format!(
             "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5{}039401CC{}{}9AFF00{}",
-            "302E302E3031",
+            "302E312E30",
             hex_index,
             replays_per_page_hex,
             request_parameters.build_aob());

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -85,7 +85,7 @@ pub async fn get_replays<A, B, C, D, E>(
         let hex_index = format!("{:02X}", i);
         let replays_per_page_hex = format!("{:02X}", replays_per_page);
         let query_string = format!(
-            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5302E302E38039401CC{}{}9AFF00{}",
+            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5302E302E39039401CC{}{}9AFF00{}",
             hex_index,
             replays_per_page_hex,
             request_parameters.build_aob());

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -85,7 +85,8 @@ pub async fn get_replays<A, B, C, D, E>(
         let hex_index = format!("{:02X}", i);
         let replays_per_page_hex = format!("{:02X}", replays_per_page);
         let query_string = format!(
-            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5302E302E30319401CC{}{}9AFF00{}",
+            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5{}039401CC{}{}9AFF00{}",
+            "302E302E3031",
             hex_index,
             replays_per_page_hex,
             request_parameters.build_aob());

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -85,7 +85,7 @@ pub async fn get_replays<A, B, C, D, E>(
         let hex_index = format!("{:02X}", i);
         let replays_per_page_hex = format!("{:02X}", replays_per_page);
         let query_string = format!(
-            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5302E302E39039401CC{}{}9AFF00{}",
+            "9295B2323131303237313133313233303038333834AD3631613565643466343631633202A5302E302E30319401CC{}{}9AFF00{}",
             hex_index,
             replays_per_page_hex,
             request_parameters.build_aob());


### PR DESCRIPTION
Broke with the patch, should be easier to fix in the future this way.